### PR TITLE
Chomp patch level if patch level is p0

### DIFF
--- a/lib/mina/rbenv/addons.rb
+++ b/lib/mina/rbenv/addons.rb
@@ -5,7 +5,7 @@ require 'mina/rbenv'
 #
 # Change it if you want to upgrade or install a new ruby version.
 
-set_default :rbenv_ruby_version, "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+set_default :rbenv_ruby_version, "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}".chomp('-p0')
 
 # ### rbenv_git_url
 # Sets the rbenv git url to clone


### PR DESCRIPTION
Fixes rbenv install since it assumes 2.3.0 and not 2.3.0-p0.

Also fixes issue: https://github.com/stas/mina-rbenv-addons/issues/1 
